### PR TITLE
Time calibration.

### DIFF
--- a/Src/Headers/PulseGenerator.h
+++ b/Src/Headers/PulseGenerator.h
@@ -31,6 +31,39 @@
 
 #include <vector>
 
+// To divide the NOMINAL_CLOCK_FREQ by before passing it to
+// the PWM peripheral.  Trying to nominally time the PWM
+// such that 32 clocks is 1 탎ec or 31.25 MHz clock.
+// Clocks to write a FIFO byte is determined by RNG1 of
+// the PWM.  Not documented but I have found that RNG1
+// takes  a few clocks to take effect so the duration field
+// set by RNG1 is one pulse segment ahead of its state...
+//
+// Don't know if a full word is required but that is why I
+// chose 32 bits for 1 탎ec just in case...
+//
+// This is the divider which should be passed to
+// Clock::PwmSetDivider(int divider)
+//
+// Also assumes base clock is (running at 500MHz undivided)
+#define CLOCK_DIV 16
+
+// Use this to "dial in" the timing to you desitred accuracy.
+//
+// i.e using these default settings I get 31.25 MHz base clock
+// rate.  In an ideal world this would mean a RING1 of 312
+// will produce pulse segments of 10 탎ec.  On my RPI I measured
+// a pulse segment duration of 10.45 탎ec. Similarly, a 624
+// value for RNG1 produced 20.90 탎ec.  To get exactly 10 탎ec
+// I need 4 fewer PWM clocks for a difference of 0.4 MHz.
+// I can adjust the ideal timing to actual conditions with
+// the following constant..
+#define CLOCK_CALIBRATION -0.2
+
+// Use this macro when you know you want a pulse segment
+// that should have a duration of a known micro seconds.
+#define MICROSEC_TO_RNG1(x) (int)((float) x * ((500.0f / CLOCK_DIV) + CLOCK_CALIBRATION))
+
 struct Pulse
 {
 	PinState State;

--- a/Src/Tests/Tests.cpp
+++ b/Src/Tests/Tests.cpp
@@ -205,7 +205,7 @@ void Test::Display(FourDigitSevenSegmentDisplay& display)
 }
 
 #define SOURCE_BUFFER_FRAMES 42
-#define CLOCK_DIV 80 //# to divide the NOMINAL_CLOCK_FREQ by before passing it to the PWM peripheral.
+#define CLOCK_DIVTEST 80 //# to divide the NOMINAL_CLOCK_FREQ by before passing it to the PWM peripheral.
 //gpio frames per second is a product of the nominal clock frequency divided by BITS_PER_CLOCK and divided again by CLOCK_DIV
 //At 500,000 frames/sec, memory bandwidth does not appear to be an issue (jitter of -1 to +2 uS)
 //attempting 1,000,000 frames/sec results in an actual 800,000 frames/sec, though with a lot of jitter.
@@ -390,7 +390,7 @@ void Test::DmaGpioPwmGated(Dma& dma, Pwm& pwm, Clock& clock, Gpio& gpio, int out
 	
 	//configure PWM clock:
 	clock.PwmDisable();
-	clock.PwmSetDivider(CLOCK_DIV);
+	clock.PwmSetDivider(CLOCK_DIVTEST);
 	clock.PwmEnable();
 		
 	pwm.Stop();	
@@ -830,38 +830,41 @@ void Test::GeneratePulseTrain(PulseGenerator& pulseGenerator)
 {
 	PulseTrain pulseTrain(1 << 5);
 
-	pulseTrain.Add(PinState::Low, 150);
-	pulseTrain.Add(PinState::High,50);
-	
-	pulseTrain.Add(PinState::Low, 300);
-	pulseTrain.Add(PinState::High, 50);
+	for (int i = 0; i < 8; i++)
+	{
+		pulseTrain.Add(PinState::Low, MICROSEC_TO_RNG1(58));
+		pulseTrain.Add(PinState::High, MICROSEC_TO_RNG1(58));
+	}
 
-	pulseTrain.Add(PinState::Low, 600);
-	pulseTrain.Add(PinState::High, 50);
+	pulseTrain.Add(PinState::Low, MICROSEC_TO_RNG1(100));
+	pulseTrain.Add(PinState::High, MICROSEC_TO_RNG1(100));
 
-	pulseTrain.Add(PinState::Low, 1200);
-	pulseTrain.Add(PinState::High, 50);
+	/*for (int i = 0; i < 8; i++)
+	{
+		pulseTrain.Add(PinState::Low, MICROSEC_TO_RNG1(58));
+		pulseTrain.Add(PinState::High, MICROSEC_TO_RNG1(58));
+	}
 
-	pulseTrain.Add(PinState::Low, 50);
-	pulseTrain.Add(PinState::High, 50);
+	pulseTrain.Add(PinState::Low, MICROSEC_TO_RNG1(100));
+	pulseTrain.Add(PinState::High, MICROSEC_TO_RNG1(100));
 
-	pulseTrain.Add(PinState::Low, 50);
-	pulseTrain.Add(PinState::High, 50);
+	for (int i = 0; i < 8; i++)
+	{
+		pulseTrain.Add(PinState::Low, MICROSEC_TO_RNG1(100));
+		pulseTrain.Add(PinState::High, MICROSEC_TO_RNG1(100));
+	}
 
-	pulseTrain.Add(PinState::Low, 50);
-	pulseTrain.Add(PinState::High, 50);
+	pulseTrain.Add(PinState::Low, MICROSEC_TO_RNG1(100));
+	pulseTrain.Add(PinState::High, MICROSEC_TO_RNG1(100));
+*/
+	for (int i = 0; i < 8; i++)
+	{
+		pulseTrain.Add(PinState::Low, MICROSEC_TO_RNG1(58));
+		pulseTrain.Add(PinState::High, MICROSEC_TO_RNG1(58));
+	}
 
-	pulseTrain.Add(PinState::Low, 50);
-	pulseTrain.Add(PinState::High, 50);
-
-	pulseTrain.Add(PinState::Low, 50);
-	pulseTrain.Add(PinState::High, 50);
-
-	pulseTrain.Add(PinState::Low, 150);
-	pulseTrain.Add(PinState::High, 150);
-
-	pulseTrain.Add(PinState::Low, 15);
-	pulseTrain.Add(PinState::High, 15);
+	pulseTrain.Add(PinState::Low, MICROSEC_TO_RNG1(58));
+	pulseTrain.Add(PinState::High, MICROSEC_TO_RNG1(58));
 
 	pulseGenerator.Add(pulseTrain);
 


### PR DESCRIPTION
Start at using second control block page for buffer 0 (not done).
Seems to still work when not crossing the buffer boundary...